### PR TITLE
Better handling of first service_base request.

### DIFF
--- a/lib/quickeebooks/online/service/service_base.rb
+++ b/lib/quickeebooks/online/service/service_base.rb
@@ -80,7 +80,7 @@ module Quickeebooks
         # store service base response
         # so it can be accessed by other methods
         def service_response
-          @service_response ||= @oauth.request(:get, qb_base_uri_with_realm_id)
+          @service_response ||= check_response(@oauth.request(:get, qb_base_uri_with_realm_id))
         end
 
         # allows for reuse of service base's xml doc


### PR DESCRIPTION
unexpected 401 responses, etc.

These were occurring when token was made invalid which should fail with AuthorizationFailure, but instead was failing with NameError on last of
 'response' variable to parse in result.
