### PR TITLE
Fix support for equal, less than, and greater than for online filters

### DIFF
--- a/lib/quickeebooks/shared/service/filter.rb
+++ b/lib/quickeebooks/shared/service/filter.rb
@@ -44,13 +44,13 @@ module Quickeebooks
         def number_to_s
           clauses = []
           if @eq
-            clauses << "#{@field} :EQUALS: #{@value}"
+            clauses << "#{@field} :EQUALS: #{@eq}"
           end
           if @gt
-            clauses << "#{@field} :GreaterThan: #{@value}"
+            clauses << "#{@field} :GreaterThan: #{@gt}"
           end
           if @lt
-            clauses << "#{@field} :LessThan: #{@value}"
+            clauses << "#{@field} :LessThan: #{@lt}"
           end
           clauses.join(" :AND: ")
         end

--- a/spec/quickeebooks/online/services/filter_spec.rb
+++ b/spec/quickeebooks/online/services/filter_spec.rb
@@ -6,7 +6,7 @@ require "quickeebooks"
 describe "Quickeebooks::Online::Service::Filter" do
   before(:all) do
   end
-  
+
   it "can generate a text filter" do
     filter = Quickeebooks::Online::Service::Filter.new(:text, :field => "Name", :value => "Smith")
     filter.to_s.should == "Name :EQUALS: Smith"
@@ -27,6 +27,21 @@ describe "Quickeebooks::Online::Service::Filter" do
     time = Time.mktime(2012, 1, 2, 8, 31, 44)
     filter = Quickeebooks::Online::Service::Filter.new(:datetime, :field => "CreateTime", :after => time)
     filter.to_s.should == "CreateTime :AFTER: #{time.strftime(Quickeebooks::Online::Service::Filter::DATE_TIME_FORMAT)}"
+  end
+
+  it "can generate a number filter with equals" do
+    filter = Quickeebooks::Online::Service::Filter.new(:number, :field => "OpenBalance", :eq => 5)
+    filter.to_s.should == "OpenBalance :EQUALS: 5"
+  end
+
+  it "can generate a number filter with greater than" do
+    filter = Quickeebooks::Online::Service::Filter.new(:number, :field => "OpenBalance", :gt => 5)
+    filter.to_s.should == "OpenBalance :GreaterThan: 5"
+  end
+
+  it "can generate a number filter with less than" do
+    filter = Quickeebooks::Online::Service::Filter.new(:number, :field => "OpenBalance", :lt => 5)
+    filter.to_s.should == "OpenBalance :LessThan: 5"
   end
 
   it "can generate a datetime filter with bounded dates" do


### PR DESCRIPTION
This is related to Issue #18 which has missing support for the `gt`, `lt`, and `eq` support. Includes the fix and specs.
