### PR TITLE
Allow a Client to Reconnect or Disconnect a Given Token

### DIFF
--- a/lib/quickeebooks.rb
+++ b/lib/quickeebooks.rb
@@ -55,6 +55,7 @@ end
 
 # Services
 require 'quickeebooks/shared/service/filter'
+require 'quickeebooks/shared/service/access_token'
 
 #== Online
 
@@ -90,6 +91,7 @@ require 'quickeebooks/online/service/invoice'
 require 'quickeebooks/online/service/item'
 require 'quickeebooks/online/service/entitlement'
 require 'quickeebooks/online/service/payment'
+require 'quickeebooks/online/service/access_token'
 
 #== Windows
 
@@ -145,3 +147,4 @@ require 'quickeebooks/windows/service/customer_msg'
 require 'quickeebooks/windows/service/company_meta_data'
 require 'quickeebooks/windows/service/payment'
 require 'quickeebooks/windows/service/clazz'
+require 'quickeebooks/windows/service/access_token'

--- a/lib/quickeebooks/online/service/access_token.rb
+++ b/lib/quickeebooks/online/service/access_token.rb
@@ -1,0 +1,11 @@
+require 'quickeebooks/shared/service/access_token'
+
+module Quickeebooks
+  module Online
+    module Service
+      class AccessToken < ServiceBase
+        include Quickeebooks::Shared::Service::AccessToken
+      end
+    end
+  end
+end

--- a/lib/quickeebooks/shared/service/access_token.rb
+++ b/lib/quickeebooks/shared/service/access_token.rb
@@ -1,0 +1,43 @@
+require "quickeebooks"
+
+# See https://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0025_Intuit_Anywhere/0020_Connect/0010_From_Within_Your_App/Implement_OAuth_in_Your_App/Token_Renewal_and_Expiration
+module Quickeebooks
+  module Shared
+    module Service
+      class AccessTokenResponse
+        include ROXML
+
+        xml_convention :camelcase
+        xml_accessor :error_code
+        xml_accessor :error_message
+        xml_accessor :token,  :from => 'OAuthToken'
+        xml_accessor :secret, :from => 'OAuthTokenSecret'
+
+        def error?
+          error_code.to_i != 0
+        end
+      end
+      module AccessToken
+        # see https://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0025_Intuit_Anywhere/0060_Reference/3002_Reconnect_API
+        def reconnect
+          response = do_http_get("https://appcenter.intuit.com/api/v1/Connection/Reconnect")
+          if response && response.code.to_i == 200
+            Quickeebooks::Shared::Service::AccessTokenResponse.from_xml(response.body)
+          else
+            nil
+          end
+        end
+
+        # see https://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0025_Intuit_Anywhere/0060_Reference/3001_Disconnect_API
+        def disconnect
+          response = do_http_get("https://appcenter.intuit.com/api/v1/Connection/Disconnect")
+          if response && response.code.to_i == 200
+            Quickeebooks::Shared::Service::AccessTokenResponse.from_xml(response.body)
+          else
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/quickeebooks/windows/service/access_token.rb
+++ b/lib/quickeebooks/windows/service/access_token.rb
@@ -1,0 +1,11 @@
+require 'quickeebooks/shared/service/access_token'
+
+module Quickeebooks
+  module Windows
+    module Service
+      class AccessToken < ServiceBase
+        include Quickeebooks::Shared::Service::AccessToken
+      end
+    end
+  end
+end

--- a/spec/quickeebooks/shared/access_token_spec.rb
+++ b/spec/quickeebooks/shared/access_token_spec.rb
@@ -1,0 +1,134 @@
+require "spec_helper"
+require "fakeweb"
+require "oauth"
+require "quickeebooks"
+
+describe "Quickeebooks::Shared::Service::AccessToken" do
+
+  shared_examples "access_token_operations" do
+    context "reconnect" do
+      let(:reconnect_url){ "https://appcenter.intuit.com/api/v1/Connection/Reconnect" }
+
+      it "can successfully reconnect" do
+        xml = File.read(File.dirname(__FILE__) + "/../../xml/shared/reconnect_success.xml")
+        FakeWeb.register_uri(:get, reconnect_url, :status => ["200", "OK"], :body => xml)
+
+        response = @service.reconnect
+
+        response.error?.should    be_false
+        response.token.should  == "qye2eIdQ5H5yMyrlJflUWh712xfFXjyNnW1MfbC0rz04TfCP"
+        response.secret.should == "cyDeUNQTkFzoR0KkDn7viN6uLQxWTobeEUKW7I79"
+      end
+
+      it "can handle expired tokens" do
+        xml = File.read(File.dirname(__FILE__) + "/../../xml/shared/reconnect_error_expired.xml")
+        FakeWeb.register_uri(:get, reconnect_url, :status => ["200", "OK"], :body => xml)
+
+        response = @service.reconnect
+
+        response.error?.should        be_true
+        response.error_code.should    == "270"
+        response.error_message.should == "OAuth Token Rejected"
+      end
+
+      it "can handle out-of-bounds refresh windows" do
+        xml = File.read(File.dirname(__FILE__) + "/../../xml/shared/reconnect_error_out_of_bounds.xml")
+        FakeWeb.register_uri(:get, reconnect_url, :status => ["200", "OK"], :body => xml)
+
+        response = @service.reconnect
+
+        response.error?.should        be_true
+        response.error_code.should    == "212"
+        response.error_message.should == "Token Refresh Window Out of Bounds"
+      end
+
+
+      it "can handle unapproved apps" do
+        xml = File.read(File.dirname(__FILE__) + "/../../xml/shared/reconnect_error_not_approved.xml")
+        FakeWeb.register_uri(:get, reconnect_url, :status => ["200", "OK"], :body => xml)
+
+        response = @service.reconnect
+
+        response.error?.should        be_true
+        response.error_code.should    == "24"
+        response.error_message.should == "Invalid App Token"
+      end
+    end
+
+    context "disconnect" do
+      let(:disconnect_url){ "https://appcenter.intuit.com/api/v1/Connection/Disconnect" }
+
+      it "can successfully disconnect" do
+        xml = File.read(File.dirname(__FILE__) + "/../../xml/shared/disconnect_success.xml")
+        FakeWeb.register_uri(:get, disconnect_url, :status => ["200", "OK"], :body => xml)
+
+        response = @service.disconnect
+
+        response.error?.should be_false
+      end
+
+      it "can handle invalid tokens" do
+        xml = File.read(File.dirname(__FILE__) + "/../../xml/shared/disconnect_invalid.xml")
+        FakeWeb.register_uri(:get, disconnect_url, :status => ["200", "OK"], :body => xml)
+
+        response = @service.disconnect
+
+        response.error?.should        be_true
+        response.error_code.should    == "270"
+        response.error_message.should == "OAuth Token rejected"
+      end
+    end
+  end
+
+  context "online" do
+    before(:all) do
+      FakeWeb.allow_net_connect = false
+      qb_key = "key"
+      qb_secret = "secreet"
+
+      @realm_id = "9991111222"
+      @oauth_consumer = OAuth::Consumer.new(qb_key, qb_key, {
+          :site                 => "https://oauth.intuit.com",
+          :request_token_path   => "/oauth/v1/get_request_token",
+          :authorize_path       => "/oauth/v1/get_access_token",
+          :access_token_path    => "/oauth/v1/get_access_token"
+      })
+      @oauth = OAuth::AccessToken.new(@oauth_consumer, "blah", "blah")
+
+      @service = Quickeebooks::Online::Service::AccessToken.new
+      @service.access_token = @oauth
+      @service.instance_eval {
+        @realm_id = "9991111222"
+      }
+    end
+
+    it_behaves_like "access_token_operations"
+  end
+
+  context "windows" do
+    before(:all) do
+      FakeWeb.allow_net_connect = false
+      qb_key = "key"
+      qb_secret = "secreet"
+
+      @realm_id = "9991111222"
+      #@base_uri = "https://qbo.intuit.com/qbo36"
+      @oauth_consumer = OAuth::Consumer.new(qb_key, qb_key, {
+          :site                 => "https://oauth.intuit.com",
+          :request_token_path   => "/oauth/v1/get_request_token",
+          :authorize_path       => "/oauth/v1/get_access_token",
+          :access_token_path    => "/oauth/v1/get_access_token"
+      })
+      @oauth = OAuth::AccessToken.new(@oauth_consumer, "blah", "blah")
+
+      @service = Quickeebooks::Windows::Service::AccessToken.new
+
+      @service.access_token = @oauth
+      @service.instance_eval {
+        @realm_id = "9991111222"
+      }
+    end
+
+    it_behaves_like "access_token_operations"
+  end
+end

--- a/spec/xml/shared/disconnect_invalid.xml
+++ b/spec/xml/shared/disconnect_invalid.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PlatformResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://platform.intuit.com/api/v1">
+  <ErrorMessage>OAuth Token rejected</ErrorMessage>
+  <ErrorCode>270</ErrorCode>
+  <ServerTime>2011-11-24T17:45:27.11097Z</ServerTime>
+</PlatformResponse>

--- a/spec/xml/shared/disconnect_success.xml
+++ b/spec/xml/shared/disconnect_success.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PlatformResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://platform.intuit.com/api/v1">
+  <ErrorCode>0</ErrorCode>
+  <ServerTime>2011-11-23T17:15:27.21097Z</ServerTime>
+</PlatformResponse>

--- a/spec/xml/shared/reconnect_error_expired.xml
+++ b/spec/xml/shared/reconnect_error_expired.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReconnectResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://platform.intuit.com/api/v1">
+ <ErrorMessage>OAuth Token Rejected</ErrorMessage>
+ <ErrorCode>270</ErrorCode>
+ <ServerTime>2012-01-04T19:21:21.0782072Z</ServerTime>
+</ReconnectResponse>

--- a/spec/xml/shared/reconnect_error_not_approved.xml
+++ b/spec/xml/shared/reconnect_error_not_approved.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReconnectResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://platform.intuit.com/api/v1">
+ <ErrorMessage>Invalid App Token</ErrorMessage>
+ <ErrorCode>24</ErrorCode>
+ <ServerTime>2012-01-04T19:21:21.0782072Z</ServerTime>
+</ReconnectResponse>

--- a/spec/xml/shared/reconnect_error_out_of_bounds.xml
+++ b/spec/xml/shared/reconnect_error_out_of_bounds.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReconnectResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://platform.intuit.com/api/v1">
+ <ErrorMessage>Token Refresh Window Out of Bounds</ErrorMessage>
+ <ErrorCode>212</ErrorCode>
+ <ServerTime>2012-01-04T19:21:21.0782072Z</ServerTime>
+</ReconnectResponse>

--- a/spec/xml/shared/reconnect_success.xml
+++ b/spec/xml/shared/reconnect_success.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReconnectResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://platform.intuit.com/api/v1">
+ <ErrorMessage />
+ <ErrorCode>0</ErrorCode>
+ <ServerTime>2012-01-04T19:21:21.0782072Z</ServerTime>
+ <OAuthToken>qye2eIdQ5H5yMyrlJflUWh712xfFXjyNnW1MfbC0rz04TfCP</OAuthToken>
+ <OAuthTokenSecret>cyDeUNQTkFzoR0KkDn7viN6uLQxWTobeEUKW7I79</OAuthTokenSecret>
+</ReconnectResponse>


### PR DESCRIPTION
In our app, we need to reconnect tokens so they don't expire (every 6 mos). We have a little cronjob that runs, and so we needed a way to reconnect a token.

Also, the "Disconnect" process that occurs with IntuitOnline has to go our to their WebUI, so we can put it behind Quickeebooks and give a cleaner User Experience.
