### PR TITLE
Fix Code Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ quickeebooks.log
 tmp/*
 *.pdf
 quickeebooks-*.gem
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp/*
 *.pdf
 quickeebooks-*.gem
 coverage
+.DS_Store

--- a/quickeebooks.gemspec
+++ b/quickeebooks.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'nokogiri'
   gem.add_dependency 'activemodel'
   gem.add_dependency 'uuidtools'
-  
+
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'rcov',   '~> 0.9.8'
+  gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'rr',     '~> 1.0.2'
   gem.add_development_dependency 'rspec',  '2.11.0'
   gem.add_development_dependency 'fakeweb'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,11 @@
+# encoding: utf-8
+unless ENV['CI']
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter 'spec'
+  end
+end
+
 require "rubygems"
 require "rspec"
 


### PR DESCRIPTION
`Rcov` does not work on Ruby 1.9.x. Since the .rvmrc file loads ruby-1.9.3, issues can be expected as well as inaccurate tests. As recommend by `rcov`, coverage for ruby-1.9.3 is recommend to use `SimpleCov`.

`rake spec` will automatically generate the code coverage file. As of this PR, the coverage is 90.5%.
