### PR TITLE
Travis ruby update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 rvm:
+  - 1.9.3
   - 1.9.2
   - ruby-head
   - ree

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 rvm:
   - 1.9.2
-  - 1.9.1
   - ruby-head
   - ree


### PR DESCRIPTION
Travis.ci no longer supports 1.9.1, went ahead and updated to use 1.9.2 and 1.9.3 now.
