### PR TITLE
fix for bad uri - invoice.id.value instead of invoice.id

### DIFF
--- a/lib/quickeebooks/online/service/invoice.rb
+++ b/lib/quickeebooks/online/service/invoice.rb
@@ -29,7 +29,7 @@ module Quickeebooks
 
         def update(invoice)
           raise InvalidModelException.new("Missing required parameters for update") unless invoice.valid_for_update?
-          url = "#{url_for_resource(Quickeebooks::Online::Model::Invoice.resource_for_singular)}/#{invoice.id}"
+          url = "#{url_for_resource(Quickeebooks::Online::Model::Invoice.resource_for_singular)}/#{invoice.id.value}"
           xml = invoice.to_xml_ns
           response = do_http_post(url, valid_xml_document(xml))
           if response.code.to_i == 200


### PR DESCRIPTION
Example error I've been getting; 

URI::InvalidURIError: bad URI(is not URI?): https://qbo.sbfinance.intuit.com/resource/invoice/v2/150761966/#Quickeebooks::Online::Model::Id:0x007f86226d3bc0
