### PR TITLE
Ampersand

### DIFF
--- a/lib/quickeebooks.rb
+++ b/lib/quickeebooks.rb
@@ -76,6 +76,9 @@ require 'quickeebooks/shared/service/access_token'
 require 'quickeebooks/shared/service/sort'
 require 'quickeebooks/shared/service/operation_node'
 
+#== Model
+require 'quickeebooks/common/addressable'
+
 #== Online
 
 # Models

--- a/lib/quickeebooks/common/addressable.rb
+++ b/lib/quickeebooks/common/addressable.rb
@@ -1,0 +1,66 @@
+module Quickeebooks
+  module Model
+    module Addressable
+
+      def self.included(base)
+        base.send :include, InstanceMethods
+        base.extend ClassMethods
+      end
+      
+      module ClassMethods
+      end
+      
+      module InstanceMethods
+        def phone=(phone)
+          self.phones ||= []
+          self.phones << phone
+        end
+
+        def address=(address)
+          self.addresses ||= []
+          self.addresses << address
+        end
+
+        def billing_address
+          select_address("Billing")
+        end
+
+        def shipping_address
+          select_address("Shipping")
+        end
+
+        def primary_phone
+          select_phone("Primary")
+        end
+
+        def secondary_phone
+          select_phone("Secondary")
+        end
+
+        def mobile_phone
+          select_phone("Mobile")
+        end
+
+        def fax
+          select_phone("Fax")
+        end
+
+        def pager
+          select_phone("Pager")
+        end
+
+        private
+
+        def select_phone(type)
+          phones.detect { |phone| phone.device_type == type }
+        end
+
+        def select_address(tag)
+          addresses.detect { |address| address.tag == tag }
+        end
+        
+      end # InstanceMethods
+
+    end
+  end
+end

--- a/lib/quickeebooks/online/model/customer.rb
+++ b/lib/quickeebooks/online/model/customer.rb
@@ -16,6 +16,8 @@ module Quickeebooks
       class Customer < Quickeebooks::Online::Model::IntuitType
         include ActiveModel::Validations
         include OnlineEntityModel
+        include Quickeebooks::Model::Addressable
+
         XML_NODE = "Customer"
         REST_RESOURCE = "customer"
 

--- a/lib/quickeebooks/online/model/customer.rb
+++ b/lib/quickeebooks/online/model/customer.rb
@@ -29,11 +29,40 @@ module Quickeebooks
         end
 
         def billing_address
-          addresses.detect { |address| address.tag == "Billing" }
+          select_address("Billing")
         end
 
         def shipping_address
-          addresses.detect { |address| address.tag == "Shipping" }
+          select_address("Shipping")
+        end
+
+        def primary_phone
+          select_phone("Primary")
+        end
+
+        def secondary_phone
+          select_phone("Secondary")
+        end
+
+        def mobile_phone
+          select_phone("Mobile")
+        end
+
+        def fax
+          select_phone("Fax")
+        end
+
+        def pager
+          select_phone("Pager")
+        end
+
+        private
+        def select_phone(type)
+          phones.detect { |phone| phone.device_type == type }
+        end
+
+        def select_address(tag)
+          addresses.detect { |address| address.tag == tag }
         end
 
       end

--- a/lib/quickeebooks/online/model/vendor.rb
+++ b/lib/quickeebooks/online/model/vendor.rb
@@ -14,7 +14,8 @@ module Quickeebooks
       class Vendor < Quickeebooks::Online::Model::IntuitType
         include ActiveModel::Validations
         include OnlineEntityModel
-        
+        include Quickeebooks::Model::Addressable
+
         XML_NODE = "Vendor"
         REST_RESOURCE = "vendor"
 

--- a/lib/quickeebooks/online/service/service_base.rb
+++ b/lib/quickeebooks/online/service/service_base.rb
@@ -75,6 +75,13 @@ module Quickeebooks
           Nokogiri::XML(xml)
         end
 
+        def escape_filter(str)
+          # Ampersand needs to double encoded within an Oath request.
+          # CGI.escape will take the #26 and properly turn it into #2526
+          str.gsub!('&','%26')
+          CGI.escape(str)
+        end
+
         def valid_xml_document(xml)
           %Q{<?xml version="1.0" encoding="utf-8"?>\n#{xml.strip}}
         end
@@ -86,7 +93,7 @@ module Quickeebooks
 
           if filters.is_a?(Array) && filters.length > 0
             filter_string = filters.collect { |f| f.to_s }
-            post_body_lines << "Filter=#{CGI.escape(filter_string.join(" :AND: "))}"
+            post_body_lines << "Filter=#{escape_filter(filter_string.join(" :AND: "))}"
           end
 
           post_body_lines << "PageNum=#{page}"

--- a/lib/quickeebooks/windows/model/customer.rb
+++ b/lib/quickeebooks/windows/model/customer.rb
@@ -13,6 +13,7 @@ module Quickeebooks
     module Model
       class Customer < Quickeebooks::Windows::Model::IntuitType
         include ActiveModel::Validations
+        include Quickeebooks::Model::Addressable
 
         DEFAULT_TYPE_OF = 'Person'
         XML_COLLECTION_NODE = 'Customers'
@@ -81,14 +82,6 @@ module Quickeebooks
           active == 'true'
         end
         
-        def billing_address
-          addresses.detect { |address| address.tag == "Billing" }
-        end
-
-        def shipping_address
-          addresses.detect { |address| address.tag == "Shipping" }
-        end
-        
         def valid_for_update?
           if sync_token.nil?
             errors.add(:sync_token, "Missing required attribute SyncToken for update")
@@ -112,10 +105,6 @@ module Quickeebooks
           self.email = Quickeebooks::Windows::Model::Email.new(email_address)
         end
         
-        def address=(address)
-          self.addresses ||= []
-          self.addresses << address
-        end
 
         # To delete an account Intuit requires we provide Id and SyncToken fields
         def valid_for_deletion?

--- a/lib/quickeebooks/windows/model/vendor.rb
+++ b/lib/quickeebooks/windows/model/vendor.rb
@@ -5,6 +5,7 @@ module Quickeebooks
   module Windows
     module Model
       class Vendor < Quickeebooks::Windows::Model::IntuitType
+        include Quickeebooks::Model::Addressable
         
         xml_convention :camelcase
         xml_accessor :vendor_id, :from => 'VendorId', :as => Quickeebooks::Windows::Model::VendorId

--- a/spec/quickeebooks/online/customer_spec.rb
+++ b/spec/quickeebooks/online/customer_spec.rb
@@ -10,10 +10,15 @@ describe "Quickeebooks::Online::Model::Customer" do
     customer.meta_data.create_time.year.should == create_time.year
     customer.addresses.count.should == 2
 
-    customer.addresses.first.line1.should == "123 Main St."
+    customer.billing_address.line1.should == "123 Main St."
+    customer.shipping_address.line1.should == "123 Shipping St."
 
-    customer.phones.size.should == 2
-    customer.phones.first.free_form_number.should == "(408) 555-1212"
+    customer.phones.size.should == 5
+    customer.primary_phone.free_form_number.should == "(408) 555-1212"
+    customer.secondary_phone.free_form_number.should == "(408) 555-1213"
+    customer.mobile_phone.free_form_number.should == "(408) 555-1214"
+    customer.fax.free_form_number.should == "(408) 555-1215"
+    customer.pager.free_form_number.should == "(408) 555-1216"
 
     customer.email.address.should == "johndoe@gmail.com"
 

--- a/spec/quickeebooks/online/services/service_base_spec.rb
+++ b/spec/quickeebooks/online/services/service_base_spec.rb
@@ -106,6 +106,18 @@ describe "Quickeebooks::Online::Service::ServiceBase" do
       @service.send(:fetch_collection, @model, [filter])
     end
 
+    it "with an ampersand in filter value" do
+
+      filter = Quickeebooks::Online::Service::Filter.new(:text, :field => "Name", :value => "Smith & Gentry")
+
+      @service.should_receive(:do_http_post).with(@url,
+        "Filter=Name+%3AEQUALS%3A+Smith+%2526+Gentry&PageNum=1&ResultsPerPage=20",
+        {},
+        {"Content-Type"=>"application/x-www-form-urlencoded"})
+
+      @service.send(:fetch_collection, @model, [filter])
+    end
+
     it "paginates" do
       @service.should_receive(:do_http_post).with(@url,
         "PageNum=2&ResultsPerPage=20",

--- a/spec/xml/online/customer.xml
+++ b/spec/xml/online/customer.xml
@@ -17,7 +17,7 @@
     <Tag>Billing</Tag>
   </Address>
   <Address>
-    <Line1>123 Main St.</Line1>
+    <Line1>123 Shipping St.</Line1>
     <Line2>Suite 400</Line2>
     <City>San Diego</City>
     <Country>USA</Country>
@@ -30,8 +30,20 @@
     <FreeFormNumber>(408) 555-1212</FreeFormNumber>
   </Phone>
   <Phone>
+    <DeviceType>Secondary</DeviceType>
+    <FreeFormNumber>(408) 555-1213</FreeFormNumber>
+  </Phone>
+  <Phone>
     <DeviceType>Mobile</DeviceType>
-    <FreeFormNumber>(831) 334-0987</FreeFormNumber>
+    <FreeFormNumber>(408) 555-1214</FreeFormNumber>
+  </Phone>
+  <Phone>
+    <DeviceType>Fax</DeviceType>
+    <FreeFormNumber>(408) 555-1215</FreeFormNumber>
+  </Phone>
+  <Phone>
+    <DeviceType>Pager</DeviceType>
+    <FreeFormNumber>(408) 555-1216</FreeFormNumber>
   </Phone>
   <WebSite>
     <URI>http://blah.com</URI>


### PR DESCRIPTION
An ampersand within a filter does not work.

CGI.escape does the right thing in that it converts the '&' to '%26', but this was not good enough to find the record by filter.

I tried everything under the sun but finally got the '%2526' to work. As a goof, I put '%26' in for the filter value e.g. "Smith %26 Gentry" and CGI.escape converted it to:

```
BODY(String) = "Filter=Name+%3AEQUALS%3A+Smith+%2526+Gentry&PageNum=1&ResultsPerPage=20"
```

Spec passed.

After this I searched around and the best explanation may be this article. https://dev.twitter.com/discussions/1533

I put some thought (briefly) on where to put the fix and within Filter.new didn't seem right. This is more of an escaping issue within an OAuth request (if the above article/posters are correct) so that is how I approached the fix.
