### PR TITLE
added spec for Employee service

### DIFF
--- a/spec/quickeebooks/online/services/employee_spec.rb
+++ b/spec/quickeebooks/online/services/employee_spec.rb
@@ -1,0 +1,83 @@
+describe "Quickeebooks::Online::Service::Employee" do
+  before(:all) do
+    construct_oauth_service :employee
+  end
+
+  it "can fetch a list of employees" do
+    xml = onlineFixture("employees.xml")
+    url = @service.url_for_resource(Quickeebooks::Online::Model::Employee.resource_for_collection)
+    FakeWeb.register_uri(:post, url, :status => ["200", "OK"], :body => xml)
+    employees = @service.list
+    employees.current_page.should == 1
+    employees.entries.count.should == 1
+    employees.entries.first.name.should == "John Simpson"
+  end
+
+  it "can create a employee" do
+    xml = onlineFixture("employee.xml")
+    url = @service.url_for_resource(Quickeebooks::Online::Model::Employee.resource_for_singular)
+    FakeWeb.register_uri(:post, url, :status => ["200", "OK"], :body => xml)
+    employee = Quickeebooks::Online::Model::Employee.new
+    employee.name = "John Doe"
+    result = @service.create(employee)
+    result.id.value.to_i.should > 0
+  end
+
+  it "can delete a employee" do
+    url = "#{@service.url_for_resource(Quickeebooks::Online::Model::Employee.resource_for_singular)}/11?methodx=delete"
+    FakeWeb.register_uri(:post, url, :status => ["200", "OK"])
+    employee = Quickeebooks::Online::Model::Employee.new
+    employee.id = Quickeebooks::Online::Model::Id.new("11")
+    employee.sync_token = 0
+    result = @service.delete(employee)
+    result.should == true
+  end
+
+  it "cannot delete a employee with missing required fields for deletion" do
+    employee = Quickeebooks::Online::Model::Employee.new
+    expect { @service.delete(employee) }.to raise_exception(InvalidModelException, "Missing required parameters for delete")
+  end
+
+  it "exception is raised when we try to create an invalid account" do
+    employee = Quickeebooks::Online::Model::Employee.new
+    expect { @service.create(employee) }.to raise_exception InvalidModelException
+  end
+
+  it "cannot update an invalid employee" do
+    employee = Quickeebooks::Online::Model::Employee.new
+    employee.name = "John Bilby"
+    expect { @service.update(employee) }.to raise_exception InvalidModelException
+  end
+
+  it "can fetch a employee by id" do
+    xml = onlineFixture("employee.xml")
+    url = "#{@service.url_for_resource(Quickeebooks::Online::Model::Employee.resource_for_singular)}/11"
+    FakeWeb.register_uri(:get, url, :status => ["200", "OK"], :body => xml)
+    employee = @service.fetch_by_id(11)
+    employee.name.should == "John Simpson"
+  end
+
+  it "can update a employee" do
+    xml2 = onlineFixture("employee2.xml")
+    employee = Quickeebooks::Online::Model::Employee.new
+    employee.name = "John Doe"
+    employee.id = Quickeebooks::Online::Model::Id.new("1")
+    employee.sync_token = 2
+
+    url = "#{@service.url_for_resource(Quickeebooks::Online::Model::Employee.resource_for_singular)}/#{employee.id.value}"
+    FakeWeb.register_uri(:post, url, :status => ["200", "OK"], :body => xml2)
+    updated = @service.update(employee)
+    updated.name.should == "John Doe"
+  end
+
+  it 'Can update a fetched employee' do
+    xml = onlineFixture("employee.xml")
+    url = "#{@service.url_for_resource(Quickeebooks::Online::Model::Employee.resource_for_singular)}/11"
+    FakeWeb.register_uri(:get, url, :status => ["200", "OK"], :body => xml)
+    employee = @service.fetch_by_id(11)
+    url = "#{@service.url_for_resource(Quickeebooks::Online::Model::Employee.resource_for_singular)}/#{employee.id.value}"
+    FakeWeb.register_uri(:post, url, :status => ["200", "OK"], :body => xml)
+    updated = @service.update(employee)
+  end
+
+end

--- a/spec/xml/online/employee2.xml
+++ b/spec/xml/online/employee2.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Employee xmlns="http://www.intuit.com/sb/cdm/v2" xmlns:ns2="http://www.intuit.com/sb/cdm/qbo">
+<Id>13</Id>
+<SyncToken>0</SyncToken>
+<MetaData>
+<CreateTime>2010-09-10T00:55:25-07:00</CreateTime>
+<LastUpdatedTime>2010-09-10T00:55:25-07:00</LastUpdatedTime>
+</MetaData>
+<Name>John Doe</Name>
+<Address>
+<Line1>21215 Burbank Boulevard, Ste. 100</Line1>
+<Line2></Line2>
+<City>Woodland Hills</City>
+<CountrySubDivisionCode>CA</CountrySubDivisionCode>
+<PostalCode>91367</PostalCode>
+</Address>
+<Phone>
+<FreeFormNumber>(818) 936-7800</FreeFormNumber>
+</Phone>
+<Phone>
+<DeviceType>Mobile</DeviceType>
+<FreeFormNumber>(818) 436-8225</FreeFormNumber>
+</Phone>
+<Email>
+<Address>john.simpson@mint.com</Address>
+</Email>
+<GivenName>John</GivenName>
+<FamilyName>Simpson</FamilyName>
+<BillableTime>false</BillableTime>
+<HiredDate>9999-12-31-08:00</HiredDate>
+</Employee>

--- a/spec/xml/online/employees.xml
+++ b/spec/xml/online/employees.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<qbo:SearchResults xmlns="http://www.intuit.com/sb/cdm/qbo" xmlns:qbp="http://www.intuit.com/sb/cdm/v2" xmlns:qbo="http://www.intuit.com/sb/cdm/qbopayroll/v1">  <qbo:CdmCollections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Employees">
+    <Employee>
+      <Id>3</Id>
+      <SyncToken>0</SyncToken>
+      <MetaData>
+        <CreateTime>2010-09-10T00:55:25-07:00</CreateTime>
+        <LastUpdatedTime>2010-09-10T00:55:25-07:00</LastUpdatedTime>
+      </MetaData>
+      <Name>John Simpson</Name>
+      <Address>
+        <Line1>21215 Burbank Boulevard, Ste. 100</Line1>
+        <Line2></Line2>
+        <City>Woodland Hills</City>
+        <CountrySubDivisionCode>CA</CountrySubDivisionCode>
+        <PostalCode>91367</PostalCode>
+      </Address>
+      <Phone>
+        <FreeFormNumber>(818) 936-7800</FreeFormNumber>
+      </Phone>
+      <Phone>
+        <DeviceType>Mobile</DeviceType>
+        <FreeFormNumber>(818) 436-8225</FreeFormNumber>
+      </Phone>
+      <Email>
+        <Address>john.simpson@mint.com</Address>
+      </Email>
+      <GivenName>John</GivenName>
+      <FamilyName>Simpson</FamilyName>
+      <BillableTime>false</BillableTime>
+      <HiredDate>9999-12-31-08:00</HiredDate>
+    </Employee>
+  </qbo:CdmCollections>
+  <qbo:Count>1</qbo:Count>
+  <qbo:CurrentPage>1</qbo:CurrentPage>
+</qbo:SearchResults>


### PR DESCRIPTION
One thing I'd like feedback on was that my "employees.xml" file was based on copying the Sample Retrieve Response XML listed on this page in the docs:

https://ipp.developer.intuit.com/0010_Intuit_Partner_Platform/0050_Data_Services/0400_QuickBooks_Online/Employee

However, I had to change around the xml name space params to match the existing pattern of expected XML.  I modeled it on the "vendors.xml" file.
