### PR TITLE
Added to support to return results as Hash instead of ROXML object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 .DS_Store
 Gemfile.lock
 .rvmrc
+/.idea

--- a/lib/quickeebooks.rb
+++ b/lib/quickeebooks.rb
@@ -32,9 +32,8 @@ module Quickeebooks
       end
     end
 
-
     def result_format=(format=:object)
-      case format
+      case format.to_s.downcase.to_sym
         when :hash
           @format = :hash
         else

--- a/lib/quickeebooks.rb
+++ b/lib/quickeebooks.rb
@@ -31,6 +31,29 @@ module Quickeebooks
         logger.flush if logger.respond_to?(:flush)
       end
     end
+
+
+    def result_format=(format=:object)
+      case format
+        when :hash
+          @format = :hash
+        else
+          @format = :object
+      end
+    end
+
+    def result_format
+      @format ||= :object
+    end
+
+    def hash_result_format?
+      result_format == :hash
+    end
+
+    def object_result_format?
+      result_format == :object
+    end
+
   end # << self
 
   class Collection

--- a/lib/quickeebooks/common/service_crud.rb
+++ b/lib/quickeebooks/common/service_crud.rb
@@ -5,7 +5,7 @@ module ServiceCRUD
     xml = object.to_xml_ns
     response = do_http_post(url_for_resource(model.resource_for_singular), valid_xml_document(xml))
     if response.code.to_i == 200
-      model.from_xml(response.body)
+      parse_result(response.body)
     else
       nil
     end
@@ -15,7 +15,7 @@ module ServiceCRUD
     url = "#{url_for_resource(model.resource_for_singular)}/#{id}"
     response = do_http_get(url)
     if response && response.code.to_i == 200
-      model.from_xml(response.body)
+      parse_result(response.body)
     else
       nil
     end
@@ -27,7 +27,7 @@ module ServiceCRUD
     xml = object.to_xml_ns
     response = do_http_post(url, valid_xml_document(xml))
     if response.code.to_i == 200
-      model.from_xml(response.body)
+      parse_result(response.body)
     else
       nil
     end
@@ -42,7 +42,7 @@ module ServiceCRUD
   end
 
   def list(filters = [], page = 1, per_page = 20, sort = nil, options = {})
-    fetch_collection(model, filters, page, per_page, sort, options)
+    fetch_collection(filters, page, per_page, sort, options)
   end
 
   def model

--- a/lib/quickeebooks/online/service/account.rb
+++ b/lib/quickeebooks/online/service/account.rb
@@ -7,7 +7,7 @@ module Quickeebooks
       class Account < ServiceBase
 
         def list(filters = [], page = 1, per_page = 20, sort = nil, options = {})
-          fetch_collection(Quickeebooks::Online::Model::Account, filters, page, per_page, sort, options)
+          fetch_collection(filters, page, per_page, sort, options)
         end
 
         def create(account)
@@ -15,7 +15,7 @@ module Quickeebooks
           xml = account.to_xml_ns
           response = do_http_post(url_for_resource(Quickeebooks::Online::Model::Account.resource_for_singular), valid_xml_document(xml))
           if response && response.code.to_i == 200
-            Quickeebooks::Online::Model::Account.from_xml(response.body)
+            parse_result(response.body)
           else
             nil
           end
@@ -27,7 +27,7 @@ module Quickeebooks
           url = "#{url_for_resource(Quickeebooks::Online::Model::Account.resource_for_singular)}/#{account.id}"
           response = do_http_post(url, valid_xml_document(xml))
           if response && response.code.to_i == 200
-            Quickeebooks::Online::Model::Account.from_xml(response.body)
+            parse_result(response.body)
           else
             nil
           end
@@ -35,7 +35,7 @@ module Quickeebooks
 
         def fetch_by_id(account_id)
           response = do_http_get("#{url_for_resource(Quickeebooks::Online::Model::Account.resource_for_singular)}/#{account_id}")
-          Quickeebooks::Online::Model::Account.from_xml(response.body)
+          parse_result(response.body)
         end
 
         def delete(account)

--- a/lib/quickeebooks/online/service/company_meta_data.rb
+++ b/lib/quickeebooks/online/service/company_meta_data.rb
@@ -12,7 +12,7 @@ module Quickeebooks
           url = url_for_resource(Quickeebooks::Online::Model::CompanyMetaData.resource_for_singular)
           response = do_http_get(url)
           if response && response.code.to_i == 200
-            Quickeebooks::Online::Model::CompanyMetaData.from_xml(response.body)
+            parse_result(response.body)
           else
             nil
           end

--- a/lib/quickeebooks/online/service/invoice.rb
+++ b/lib/quickeebooks/online/service/invoice.rb
@@ -14,7 +14,7 @@ module Quickeebooks
           xml = invoice.to_xml_ns
           response = do_http_post(url_for_resource(Quickeebooks::Online::Model::Invoice.resource_for_singular), valid_xml_document(xml))
           if response.code.to_i == 200
-            Quickeebooks::Online::Model::Invoice.from_xml(response.body)
+            parse_result(response.body)
           else
             nil
           end
@@ -24,7 +24,7 @@ module Quickeebooks
         # Returns: +Invoice+ object
         def fetch_by_id(invoice_id)
           response = do_http_get("#{url_for_resource(Quickeebooks::Online::Model::Invoice::REST_RESOURCE)}/#{invoice_id}")
-          Quickeebooks::Online::Model::Invoice.from_xml(response.body)
+          parse_result(response.body)
         end
 
         def update(invoice)
@@ -33,12 +33,12 @@ module Quickeebooks
           xml = invoice.to_xml_ns
           response = do_http_post(url, valid_xml_document(xml))
           if response.code.to_i == 200
-            Quickeebooks::Online::Model::Invoice.from_xml(response.body)
+            parse_result(response.body)
           else
             nil
           end
         end
-        
+
         # Fetch a +Collection+ of +Invoice+ objects
         # Arguments:
         # filters: Array of +Filter+ objects to apply
@@ -47,7 +47,7 @@ module Quickeebooks
         # sort: +Sort+ object
         # options: +Hash+ extra arguments
         def list(filters = [], page = 1, per_page = 20, sort = nil, options = {})
-          fetch_collection(Quickeebooks::Online::Model::Invoice, filters, page, per_page, sort, options)
+          fetch_collection(filters, page, per_page, sort, options)
         end
 
         # Returns the absolute path to the PDF on disk

--- a/lib/quickeebooks/online/service/item.rb
+++ b/lib/quickeebooks/online/service/item.rb
@@ -7,7 +7,7 @@ module Quickeebooks
       class Item < ServiceBase
 
         def list(filters = [], page = 1, per_page = 20, sort = nil, options = {})
-          fetch_collection(Quickeebooks::Online::Model::Item, filters, page, per_page, sort, options)
+          fetch_collection(filters, page, per_page, sort, options)
         end
 
         def create(item)
@@ -15,7 +15,7 @@ module Quickeebooks
           xml = item.to_xml_ns
           response = do_http_post(url_for_resource(Quickeebooks::Online::Model::Item.resource_for_singular), valid_xml_document(xml))
           if response && response.code.to_i == 200
-            Quickeebooks::Online::Model::Item.from_xml(response.body)
+            parse_result(response.body)
           else
             nil
           end
@@ -27,7 +27,7 @@ module Quickeebooks
           url = "#{url_for_resource(Quickeebooks::Online::Model::Item.resource_for_singular)}/#{item.id}"
           response = do_http_post(url, valid_xml_document(xml))
           if response && response.code.to_i == 200
-            Quickeebooks::Online::Model::Item.from_xml(response.body)
+            parse_result(response.body)
           else
             nil
           end
@@ -35,7 +35,7 @@ module Quickeebooks
 
         def fetch_by_id(id)
           response = do_http_get("#{url_for_resource(Quickeebooks::Online::Model::Item.resource_for_singular)}/#{id}")
-          Quickeebooks::Online::Model::Item.from_xml(response.body)
+          parse_result(response.body)
         end
 
         def delete(item)

--- a/lib/quickeebooks/online/service/service_base.rb
+++ b/lib/quickeebooks/online/service/service_base.rb
@@ -37,7 +37,6 @@ module Quickeebooks
           end
           @parser = ::Nori.new(:parser => :nokogiri,
                                :strip_namespaces => true,
-                               :delete_namespace_attributes => true,
                                :convert_tags_to => lambda { |tag| tag.snakecase.to_sym })
         end
 

--- a/lib/quickeebooks/online/service/service_base.rb
+++ b/lib/quickeebooks/online/service/service_base.rb
@@ -37,8 +37,9 @@ module Quickeebooks
             realm_id = realm_id
           end
           @parser = ::Nori.new(:parser => :nokogiri,
-                             :strip_namespaces => true,
-                             :convert_tags_to => lambda { |tag| tag.snakecase.to_sym })
+                               :strip_namespaces => true,
+                               :delete_namespace_attributes => true,
+                               :convert_tags_to => lambda { |tag| tag.snakecase.to_sym })
         end
 
         def access_token=(token)

--- a/lib/quickeebooks/online/service/service_base.rb
+++ b/lib/quickeebooks/online/service/service_base.rb
@@ -11,8 +11,7 @@ class IntuitRequestException < Exception
     super(msg)
   end
 end
-class AuthorizationFailure < Exception;
-end
+class AuthorizationFailure < Exception; end
 
 module Quickeebooks
   module Online

--- a/lib/quickeebooks/online/service/service_base.rb
+++ b/lib/quickeebooks/online/service/service_base.rb
@@ -2,14 +2,17 @@ require 'rexml/document'
 require 'uri'
 require 'cgi'
 require 'quickeebooks/common/logging'
+require 'nori'
 
 class IntuitRequestException < Exception
   attr_accessor :code, :cause
+
   def initialize(msg)
     super(msg)
   end
 end
-class AuthorizationFailure < Exception; end
+class AuthorizationFailure < Exception;
+end
 
 module Quickeebooks
   module Online
@@ -33,16 +36,19 @@ module Quickeebooks
             access_token = oauth_access_token
             realm_id = realm_id
           end
+          @parser = ::Nori.new(:parser => :nokogiri,
+                             :strip_namespaces => true,
+                             :convert_tags_to => lambda { |tag| tag.snakecase.to_sym })
         end
 
         def access_token=(token)
           @oauth = token
         end
-        
+
         def realm_id=(realm_id)
           @realm_id = realm_id
         end
-        
+
         # uri is of the form `https://qbo.intuit.com/qbo36`
         def base_url=(uri)
           @base_uri = uri
@@ -70,7 +76,7 @@ module Quickeebooks
         end
 
         private
-        
+
         def parse_xml(xml)
           Nokogiri::XML(xml)
         end
@@ -78,7 +84,7 @@ module Quickeebooks
         def escape_filter(str)
           # Ampersand needs to double encoded within an Oath request.
           # CGI.escape will take the #26 and properly turn it into #2526
-          str.gsub!('&','%26')
+          str.gsub!('&', '%26')
           CGI.escape(str)
         end
 
@@ -86,9 +92,10 @@ module Quickeebooks
           %Q{<?xml version="1.0" encoding="utf-8"?>\n#{xml.strip}}
         end
 
-        def fetch_collection(model, filters = [], page = 1, per_page = 20, sort = nil, options ={})
-          raise ArgumentError, "missing model to instantiate" if model.nil?
-          
+        def fetch_collection(filters = [], page = 1, per_page = 20, sort = nil, options ={})
+          name = self.class.to_s.split('::').last
+          model = Object.const_get(:Quickeebooks).const_get(:Online).const_get(:Model).const_get(name)
+
           post_body_lines = []
 
           if filters.is_a?(Array) && filters.length > 0
@@ -106,24 +113,37 @@ module Quickeebooks
           body = post_body_lines.join("&")
           response = do_http_post(url_for_resource(model.resource_for_collection), body, {}, {'Content-Type' => 'application/x-www-form-urlencoded'})
           if response
-            collection = Quickeebooks::Collection.new
-            xml = parse_xml(response.body)
-            begin
-              results = []
-              collection.count = xml.xpath("//qbo:SearchResults/qbo:Count")[0].text.to_i
-              if collection.count > 0
-                xml.xpath("//qbo:SearchResults/qbo:CdmCollections/xmlns:#{model::XML_NODE}").each do |xa|
-                  results << model.from_xml(xa)
+            if Quickeebooks.hash_result_format?
+              @parser.parse(response.body)
+            else
+              collection = Quickeebooks::Collection.new
+              xml = parse_xml(response.body)
+              begin
+                results = []
+                collection.count = xml.xpath("//qbo:SearchResults/qbo:Count")[0].text.to_i
+                if collection.count > 0
+                  xml.xpath("//qbo:SearchResults/qbo:CdmCollections/xmlns:#{model::XML_NODE}").each do |xa|
+                    results << model.from_xml(xa)
+                  end
                 end
+                collection.entries = results
+                collection.current_page = xml.xpath("//qbo:SearchResults/qbo:CurrentPage")[0].text.to_i
+              rescue => ex
+                raise IntuitRequestException.new("Error parsing XML: #{ex.message}")
               end
-              collection.entries = results
-              collection.current_page = xml.xpath("//qbo:SearchResults/qbo:CurrentPage")[0].text.to_i
-            rescue => ex
-              raise IntuitRequestException.new("Error parsing XML: #{ex.message}")
+              collection
             end
-            collection
           else
             nil
+          end
+        end
+
+        def parse_result(response)
+          if Quickeebooks.hash_result_format?
+            @parser.parse(response)
+          else
+            name = self.class.to_s.split('::').last
+            Object.const_get(:Quickeebooks).const_get(:Online).const_get(:Model).const_get(name).from_xml(response)
           end
         end
 
@@ -164,20 +184,20 @@ module Quickeebooks
           log "RESPONSE BODY = #{response.body}"
           status = response.code.to_i
           case status
-          when 200
-            response
-          when 302
-            raise "Unhandled HTTP Redirect"
-          when 401
-            raise AuthorizationFailure
-          when 400, 500
-            err = parse_intuit_error(response.body)
-            ex = IntuitRequestException.new(err[:message])
-            ex.code = err[:code]
-            ex.cause = err[:cause]
-            raise ex
-          else
-            raise "HTTP Error Code: #{status}, Msg: #{response.body}"
+            when 200
+              response
+            when 302
+              raise "Unhandled HTTP Redirect"
+            when 401
+              raise AuthorizationFailure
+            when 400, 500
+              err = parse_intuit_error(response.body)
+              ex = IntuitRequestException.new(err[:message])
+              ex.code = err[:code]
+              ex.cause = err[:cause]
+              raise ex
+            else
+              raise "HTTP Error Code: #{status}, Msg: #{response.body}"
           end
         end
 
@@ -199,7 +219,6 @@ module Quickeebooks
 
           error
         end
-
       end
     end
   end

--- a/quickeebooks.gemspec
+++ b/quickeebooks.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'nokogiri'
   gem.add_dependency 'activemodel'
   gem.add_dependency 'uuidtools'
+  gem.add_dependency 'nori'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'simplecov'

--- a/spec/quickeebooks/online/services/customer_spec.rb
+++ b/spec/quickeebooks/online/services/customer_spec.rb
@@ -89,6 +89,24 @@ describe "Quickeebooks::Online::Service::Customer" do
     customer.name.should == "John Doe"
   end
 
+  it "can fetch a customer by id in hash format" do
+      begin
+        Quickeebooks.result_format = :hash
+        xml = onlineFixture("customer.xml")
+        url = "#{@service.url_for_resource(Quickeebooks::Online::Model::Customer.resource_for_singular)}/99"
+        FakeWeb.register_uri(:get, url, :status => ["200", "OK"], :body => xml)
+        result = @service.fetch_by_id(99)
+        result.should be_a_kind_of(Hash)
+        result.should_not be_empty
+        result[:customer].should_not be_empty
+        customer = result[:customer]
+        customer.should_not be_empty
+        customer[:name].should == "John Doe"
+      ensure
+        Quickeebooks.result_format = :object
+      end
+    end
+
   it "can update a customer" do
     xml2 = onlineFixture("customer2.xml")
     customer = Quickeebooks::Online::Model::Customer.new

--- a/spec/quickeebooks/online/services/customer_spec.rb
+++ b/spec/quickeebooks/online/services/customer_spec.rb
@@ -13,6 +13,28 @@ describe "Quickeebooks::Online::Service::Customer" do
     accounts.entries.first.name.should == "John Doe"
   end
 
+  it "can fetch a list of customers in hash format" do
+    begin
+      Quickeebooks.result_format = :hash
+      xml = onlineFixture("customers.xml")
+      url = @service.url_for_resource(Quickeebooks::Online::Model::Customer.resource_for_collection)
+      FakeWeb.register_uri(:post, url, :status => ["200", "OK"], :body => xml)
+      result = @service.list
+      result.should be_a_kind_of(Hash)
+      result.should_not be_empty
+      result[:search_results].should_not be_empty
+      result[:search_results][:current_page] = 1
+      result[:search_results][:count] = 3
+      result[:search_results][:cdm_collections].should_not be_empty
+      customers = result[:search_results][:cdm_collections][:customer]
+      customers.should_not be_empty
+      customers.size.should == 3
+      customers.first[:name].should == "John Doe"
+    ensure
+      Quickeebooks.result_format = :object
+    end
+  end
+
   it "can fetch a list of customers with filters" do
     xml = onlineFixture("customers.xml")
     url = @service.url_for_resource(Quickeebooks::Online::Model::Customer.resource_for_collection)

--- a/spec/quickeebooks/online/services/service_base_spec.rb
+++ b/spec/quickeebooks/online/services/service_base_spec.rb
@@ -16,7 +16,7 @@ describe "Quickeebooks::Online::Service::ServiceBase" do
     xml = onlineFixture("user.xml")
     user_url = Quickeebooks::Online::Service::ServiceBase::QB_BASE_URI + "/" + @realm_id
     FakeWeb.register_uri(:get, user_url, :status => ["200", "OK"], :body => xml)
-    @service = Quickeebooks::Online::Service::ServiceBase.new
+    @service = Quickeebooks::Online::Service::Customer.new
     @service.access_token = @oauth
     @service.instance_eval {
       @realm_id = "9991111222"
@@ -79,9 +79,7 @@ describe "Quickeebooks::Online::Service::ServiceBase" do
 
   describe "#fetch_collection" do
     before do
-      @model = mock(Object)
-      @model.stub(:resource_for_collection){ "foos" }
-
+      @model = Quickeebooks::Online::Model::Customer
       @url = @service.url_for_resource(@model.resource_for_collection)
     end
 
@@ -91,7 +89,7 @@ describe "Quickeebooks::Online::Service::ServiceBase" do
         {},
         {"Content-Type"=>"application/x-www-form-urlencoded"})
 
-      @service.send(:fetch_collection, @model)
+      @service.send(:fetch_collection)
     end
 
     it "filters" do
@@ -103,7 +101,7 @@ describe "Quickeebooks::Online::Service::ServiceBase" do
         {},
         {"Content-Type"=>"application/x-www-form-urlencoded"})
 
-      @service.send(:fetch_collection, @model, [filter])
+      @service.send(:fetch_collection, [filter])
     end
 
     it "with an ampersand in filter value" do
@@ -115,7 +113,7 @@ describe "Quickeebooks::Online::Service::ServiceBase" do
         {},
         {"Content-Type"=>"application/x-www-form-urlencoded"})
 
-      @service.send(:fetch_collection, @model, [filter])
+      @service.send(:fetch_collection, [filter])
     end
 
     it "paginates" do
@@ -124,7 +122,7 @@ describe "Quickeebooks::Online::Service::ServiceBase" do
         {},
         {"Content-Type"=>"application/x-www-form-urlencoded"})
 
-      @service.send(:fetch_collection, @model, nil, 2)
+      @service.send(:fetch_collection, nil, 2)
     end
 
     it "changes per_page" do
@@ -133,7 +131,7 @@ describe "Quickeebooks::Online::Service::ServiceBase" do
         {},
         {"Content-Type"=>"application/x-www-form-urlencoded"})
 
-      @service.send(:fetch_collection, @model, nil, 1, 10)
+      @service.send(:fetch_collection, nil, 1, 10)
     end
 
     it "sorts" do
@@ -144,7 +142,7 @@ describe "Quickeebooks::Online::Service::ServiceBase" do
         {},
         {"Content-Type"=>"application/x-www-form-urlencoded"})
 
-      @service.send(:fetch_collection, @model, nil, 1, 20, sorter)
+      @service.send(:fetch_collection, nil, 1, 20, sorter)
     end
   end
 end

--- a/spec/quickeebooks/online/services/service_base_spec.rb
+++ b/spec/quickeebooks/online/services/service_base_spec.rb
@@ -5,7 +5,7 @@ describe "Quickeebooks::Online::Service::ServiceBase" do
     qb_secret = "secreet"
 
     @realm_id = "9991111222"
-    @oauth_consumer = OAuth::Consumer.new(qb_key, qb_key, {
+    @oauth_consumer = OAuth::Consumer.new(qb_key, qb_secret, {
         :site                 => "https://oauth.intuit.com",
         :request_token_path   => "/oauth/v1/get_request_token",
         :authorize_path       => "/oauth/v1/get_access_token",

--- a/spec/quickeebooks_spec.rb
+++ b/spec/quickeebooks_spec.rb
@@ -5,4 +5,20 @@ describe Quickeebooks do
     it { should be_a String }
   end
 
+  describe "Result Format" do
+    it "can set result format as :hash" do
+      Quickeebooks.result_format = :hash
+      Quickeebooks.result_format.should == :hash
+      Quickeebooks.hash_result_format?.should == true
+      Quickeebooks.object_result_format?.should == false
+    end
+
+    it "can set result format as :object" do
+      Quickeebooks.result_format = 'Object'
+      Quickeebooks.result_format.should == :object
+      Quickeebooks.hash_result_format?.should == false
+      Quickeebooks.object_result_format?.should == true
+    end
+  end
 end
+

--- a/spec/support/oauth.rb
+++ b/spec/support/oauth.rb
@@ -4,7 +4,7 @@ def construct_oauth_service(model)
   qb_key = "key"
   qb_secret = "secreet"
   @realm_id = "9991111222"
-  @oauth_consumer = OAuth::Consumer.new(qb_key, qb_key, {
+  @oauth_consumer = OAuth::Consumer.new(qb_key, qb_secret, {
       :site                 => "https://oauth.intuit.com",
       :request_token_path   => "/oauth/v1/get_request_token",
       :authorize_path       => "/oauth/v1/get_access_token",


### PR DESCRIPTION
- added a flag to return all service results in Hash format
- removed the need to explicitly specify response model since one service always maps to one model
- added specs
