### PR TITLE
Fixed resource url for item

### DIFF
--- a/lib/quickeebooks/online/model/item.rb
+++ b/lib/quickeebooks/online/model/item.rb
@@ -32,6 +32,7 @@ module Quickeebooks
         xml_accessor :expense_account_reference, :from => 'ExpenseAccountRef', :as => Quickeebooks::Online::Model::AccountReference
 
         validates_presence_of :account_reference
+        validates_length_of :name, :within => 1..100
 
         def to_xml_ns(options = {})
           to_xml_inject_ns('Item', options)


### PR DESCRIPTION
i came across a wrong resource name for items. I wonder if it might be a good idea to use

```
    def self.resource_for_collection
      self::REST_RESOURCE.pluralize
    end
```

in the `IntuitType` base class, that would also get rid of some hand written code in other models where pluralization is handled manually. the gem depends on active_support anyway.
