### PR TITLE
Change REST_RESOURCE from time_activity to time-activity

### DIFF
--- a/lib/quickeebooks/online/model/time_activity.rb
+++ b/lib/quickeebooks/online/model/time_activity.rb
@@ -12,7 +12,7 @@ module Quickeebooks
         include OnlineEntityModel
 
         XML_NODE = "TimeActivity"
-        REST_RESOURCE = "time_activity"
+        REST_RESOURCE = "time-activity"
 
         xml_accessor :txn_date, :from => 'TxnDate'
         xml_accessor :name_of, :from => 'NameOf'


### PR DESCRIPTION
The endpoint name for Quickeebooks::Online::Model::TimeActivity was set to time_activity but the correct setting is time-activity.

Reference: https://developer.intuit.com/docs/0025_quickbooksapi/0050_data_services/v2/0400_quickbooks_online/timeactivity
