### PR TITLE
Fix describe blocks that really should be it blocks

### DIFF
--- a/spec/quickeebooks/online/bill_spec.rb
+++ b/spec/quickeebooks/online/bill_spec.rb
@@ -1,6 +1,6 @@
 describe "Quickeebooks::Online::Model::Bill" do
 
-  describe "parse bill from XML" do
+  it "parse bill from XML" do
     xml = onlineFixture("bill.xml")
     bill = Quickeebooks::Online::Model::Bill.from_xml(xml)
     bill.header.doc_number.should == "2004"

--- a/spec/quickeebooks/online/employee_spec.rb
+++ b/spec/quickeebooks/online/employee_spec.rb
@@ -1,6 +1,6 @@
 describe "Quickeebooks::Online::Model::Employee" do
 
-  describe "parse employee from XML" do
+  it "parse employee from XML" do
     xml = onlineFixture("employee.xml")
     employee = Quickeebooks::Online::Model::Employee.from_xml(xml)
     employee.sync_token.should == 0

--- a/spec/quickeebooks/online/journal_entry_spec.rb
+++ b/spec/quickeebooks/online/journal_entry_spec.rb
@@ -1,5 +1,5 @@
 describe "Quickeebooks::Online::Model::JournalEntry" do
-  describe "parse invoice from XML" do
+  it "parse invoice from XML" do
     xml = onlineFixture("journal_entry.xml")
     journal_entry = Quickeebooks::Online::Model::JournalEntry.from_xml(xml)
     journal_entry.id.value.should == "381"

--- a/spec/quickeebooks/online/payment_spec.rb
+++ b/spec/quickeebooks/online/payment_spec.rb
@@ -1,6 +1,6 @@
 describe "Quickeebooks::Online::Model::Payment" do
 
-  describe "parse invoice from XML" do
+  it "parse invoice from XML" do
     xml = onlineFixture("payment.xml")
     invoice = Quickeebooks::Online::Model::Payment.from_xml(xml)
     invoice.id.value.should == "47"

--- a/spec/quickeebooks/online/sales_receipt_spec.rb
+++ b/spec/quickeebooks/online/sales_receipt_spec.rb
@@ -1,5 +1,5 @@
 describe "Quickeebooks::Online::Model::SalesReceipt" do
-  describe "parse invoice from XML" do
+  it "parse invoice from XML" do
     xml = onlineFixture("sales_receipt.xml")
     sales_receipt = Quickeebooks::Online::Model::SalesReceipt.from_xml(xml)
     sales_receipt.id.value.should == "8"

--- a/spec/quickeebooks/online/time_activity_spec.rb
+++ b/spec/quickeebooks/online/time_activity_spec.rb
@@ -1,6 +1,6 @@
 describe "Quickeebooks::Online::Model::TimeActivity" do
 
-  describe "parse time_activity from XML" do
+  it "parse time_activity from XML" do
     xml = onlineFixture("time_activity.xml")
     time_activity = Quickeebooks::Online::Model::TimeActivity.from_xml(xml)
     time_activity.sync_token.should == 0

--- a/spec/quickeebooks/online/vendor_spec.rb
+++ b/spec/quickeebooks/online/vendor_spec.rb
@@ -1,6 +1,6 @@
 describe "Quickeebooks::Online::Model::Vendor" do
 
-  describe "parse vendor from XML" do
+  it "parse vendor from XML" do
     xml = onlineFixture("vendor.xml")
     vendor = Quickeebooks::Online::Model::Vendor.from_xml(xml)
     vendor.sync_token.should == 0


### PR DESCRIPTION
As I was working on some features I noticed a test block that wasn't being executed because it was in a describe block and not in an it block. I searched the specs and found 7 instances of this. So I fixed the syntax.
