### PR TITLE
Change Online#TimeActivity validations to better match API requirements

### DIFF
--- a/spec/quickeebooks/online/time_activity_spec.rb
+++ b/spec/quickeebooks/online/time_activity_spec.rb
@@ -14,5 +14,130 @@ describe "Quickeebooks::Online::Model::TimeActivity" do
 
   end
 
+  describe 'validations' do
+    describe 'duration' do
+      it 'is not valid if no duration is provided' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.valid?
+        time_activity.errors.full_messages.should include('A duration is required')
+      end
+
+      it 'is not valid when hours/minutes and start_time/end_time are both set' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.hours = 2
+        time_activity.minutes = 12
+        time_activity.start_time = Time.now - (30 * 60) # 30 minutes ago
+        time_activity.end_time = Time.now + (30 * 60) # 30 minutes from now
+        time_activity.valid?
+        time_activity.errors.full_messages.should include('Only one duration type allowed')
+      end
+
+      it 'is valid when hours/minutes is provided' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.hours = 2
+        time_activity.minutes = 12
+        time_activity.valid?
+        time_activity.errors.full_messages.should_not include('A duration is required')
+      end
+
+      it 'is valid when start_time/end_time is provided' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.start_time = Time.now - (30 * 60) # 30 minutes ago
+        time_activity.end_time = Time.now + (30 * 60) # 30 minutes from now
+        time_activity.valid?
+        time_activity.errors.full_messages.should_not include('A duration is required')
+      end
+    end
+    describe 'name_of' do
+      it 'is valid when set to Employee' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.name_of = 'Employee'
+        time_activity.valid?
+        time_activity.errors.messages.keys.should_not include(:name_of)
+      end
+
+      it 'is valid when set to Vendor' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.name_of = 'Vendor'
+        time_activity.valid?
+        time_activity.errors.messages.keys.should_not include(:name_of)
+      end
+
+      it 'is not valid when not provided' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.valid?
+        time_activity.errors.full_messages.should include('Name of is not included in the list')
+      end
+    end
+    describe 'customer_id' do
+      it 'is valid when billable_status is Billable' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.billable_status = 'Billable'
+        time_activity.customer_id = 5
+        time_activity.valid?
+        time_activity.errors.messages.keys.should_not include(:customer_id)
+      end
+
+      it 'is required when billable_status is Billable' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.billable_status = 'Billable'
+        time_activity.valid?
+        time_activity.errors.full_messages.should include("Customer can't be blank")
+      end
+
+      it 'is not required when billable_status is not Billable' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.billable_status = 'NotBillable'
+        time_activity.valid?
+        time_activity.errors.messages.keys.should_not include(:customer_id)
+      end
+    end
+    describe 'hourly_rate' do
+      it 'is valid when billable_status is Billable' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.billable_status = 'Billable'
+        time_activity.hourly_rate = 5
+        time_activity.valid?
+        time_activity.errors.messages.keys.should_not include(:hourly_rate)
+      end
+
+      it 'is required when billable_status is Billable' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.billable_status = 'Billable'
+        time_activity.valid?
+        time_activity.errors.full_messages.should include("Hourly rate can't be blank")
+      end
+
+      it 'is not required when billable_status is not Billable' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.billable_status = 'NotBillable'
+        time_activity.valid?
+        time_activity.errors.messages.keys.should_not include(:hourly_rate)
+      end
+    end
+    describe 'billable_status' do
+      %w(Billable NotBillable HasBeenBilled).each do |status|
+        it "is valid with status #{status}" do
+          time_activity = Quickeebooks::Online::Model::TimeActivity.new
+          time_activity.billable_status = status
+          time_activity.valid?
+          time_activity.errors.messages.keys.should_not include(:billable_status)
+        end
+      end
+
+      it 'is invalid with unknown status' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.billable_status = 'FooBarBaz'
+        time_activity.valid?
+        time_activity.errors.full_messages.should include('Billable status is not included in the list')
+      end
+
+      it 'is valid when not set' do
+        time_activity = Quickeebooks::Online::Model::TimeActivity.new
+        time_activity.valid?
+        time_activity.errors.messages.keys.should_not include(:billable_status)
+      end
+    end
+  end
 
 end


### PR DESCRIPTION
Currently Online#TimeActivity enforces a validation that doesn't match up to the API. This change makes the validations more closely match up to what the API requires. This based on what [the documentation](https://developer.intuit.com/docs/0025_quickbooksapi/0050_data_services/v2/0400_quickbooks_online/timeactivity) says and lots of test requests.
