### PR TITLE
Intuit no longer requires an address on a customer for Windows flavor

### DIFF
--- a/lib/quickeebooks/windows/model/customer.rb
+++ b/lib/quickeebooks/windows/model/customer.rb
@@ -74,7 +74,6 @@ module Quickeebooks
         xml_accessor :total_expense, :from => 'TotalExpense', :as => Quickeebooks::Windows::Model::Price
 
         validates_length_of :name, :minimum => 1
-        validate :require_an_address
         validate :name_cannot_contain_invalid_characters
         validate :email_address_is_valid
         
@@ -124,12 +123,6 @@ module Quickeebooks
             unless address.index('@') && address.index('.')
               errors.add(:email, "Email address must contain @ and . (dot)")
             end
-          end
-        end
-        
-        def require_an_address
-          if addresses.nil? || (addresses.is_a?(Array) && addresses.empty?)
-            errors.add(:addresses, "Must provide at least one address for this Customer.")
           end
         end
 

--- a/spec/quickeebooks/windows/services/customer_spec.rb
+++ b/spec/quickeebooks/windows/services/customer_spec.rb
@@ -90,20 +90,6 @@ describe "Quickeebooks::Windows::Service::Customer" do
     customer.errors.keys.include?(:name).should == true
   end
 
-  it "cannot create a customer with no address" do
-    customer = Quickeebooks::Windows::Model::Customer.new
-    service = Quickeebooks::Windows::Service::Customer.new
-    service.access_token = @oauth
-    service.realm_id = @realm_id
-    customer.name = "Bobs Plumbing"
-    lambda do
-      service.create(customer)
-    end.should raise_error(InvalidModelException)
-
-    customer.valid?.should == false
-    customer.errors.keys.include?(:addresses).should == true
-  end
-
   it "cannot create a customer with an invalid email" do
     customer = Quickeebooks::Windows::Model::Customer.new
     service = Quickeebooks::Windows::Service::Customer.new


### PR DESCRIPTION
Here is a request to add a customer with no address;

```
    <Add xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" RequestId="946304228132838942111d8aeff96dd1" xmlns="http://www.intuit.com/sb/cdm/v2">
        <ExternalRealmId>762087535</ExternalRealmId>
        <Object xsi:type="Customer"> 
            <TypeOf>Person</TypeOf> 
            <Name>Brian Bosworth</Name> 
            <Phone> 
                <DeviceType>LandLine</DeviceType> 
                <FreeFormNumber>5552221212</FreeFormNumber> 
                <Default>true</Default> 
                <Tag>Business</Tag> 
            </Phone> 
            <Email> 
                <Address>troy+brian@testing.com</Address> 
                <Default>true</Default> 
                <Tag>Business</Tag> 
            </Email> 
            <DBAName /> 
        </Object>
    </Add>
```

Here is the response;
        <RestResponse xmlns="http://www.intuit.com/sb/cdm/v2">
            <Success RequestId="946304228132838942111d8aeff96dd1">
                <PartyRoleRef>
                    <Id idDomain="NG">927762</Id>
                    <SyncToken>1</SyncToken>
                    <LastUpdatedTime>2013-08-26T03:39:56Z</LastUpdatedTime>
                    <PartyReferenceId idDomain="NG">1010891</PartyReferenceId>
                </PartyRoleRef>
                <RequestName>CustomerAdd</RequestName>
                <ProcessedTime>2013-08-26T03:39:56Z</ProcessedTime>
            </Success>
        </RestResponse>
This customer does show up in QBW after a sync.

Did I verify this correctly?? Hope I'm not missing something :)
