### PR TITLE
Modify customer address validation to allow no address on Windows flavor

### DIFF
--- a/lib/quickeebooks/windows/model/customer.rb
+++ b/lib/quickeebooks/windows/model/customer.rb
@@ -128,8 +128,8 @@ module Quickeebooks
         end
         
         def require_an_address
-          if addresses.nil? || (addresses.is_a?(Array) && addresses.empty?)
-            errors.add(:addresses, "Must provide at least one address for this Customer.")
+          if (addresses.is_a?(Array) && addresses.empty?)
+            errors.add(:addresses, "Cannot send an empty address.")
           end
         end
 

--- a/spec/quickeebooks/windows/services/customer_spec.rb
+++ b/spec/quickeebooks/windows/services/customer_spec.rb
@@ -90,18 +90,28 @@ describe "Quickeebooks::Windows::Service::Customer" do
     customer.errors.keys.include?(:name).should == true
   end
 
-  it "cannot create a customer with no address" do
+  it "cannot create a customer with an empty address" do
     customer = Quickeebooks::Windows::Model::Customer.new
     service = Quickeebooks::Windows::Service::Customer.new
     service.access_token = @oauth
     service.realm_id = @realm_id
     customer.name = "Bobs Plumbing"
+    customer.addresses = []
     lambda do
       service.create(customer)
     end.should raise_error(InvalidModelException)
 
     customer.valid?.should == false
     customer.errors.keys.include?(:addresses).should == true
+  end
+
+  it "can create a customer with no address" do
+    customer = Quickeebooks::Windows::Model::Customer.new
+    service = Quickeebooks::Windows::Service::Customer.new
+    service.access_token = @oauth
+    service.realm_id = @realm_id
+    customer.name = "Bobs Plumbing"
+    customer.valid?.should == true
   end
 
   it "cannot create a customer with an invalid email" do


### PR DESCRIPTION
At first I just removed the validation, but I think something should be there - since sending an empty address does fail.

You are able to send nothing at all, customer.addresses = nil seems to work;

```
    <Add xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" RequestId="95bd8691b4b6d8a8e20d4a1eea28349c" xmlns="http://www.intuit.com/sb/cdm/v2">
        <ExternalRealmId>762087535</ExternalRealmId>
        <Object xsi:type="Customer"> 
            <TypeOf>Person</TypeOf> 
            <Name>Steve Klabnick</Name> 
            <Phone> 
                <DeviceType>LandLine</DeviceType> 
                <FreeFormNumber>6678881212</FreeFormNumber> 
                <Default>true</Default> 
                <Tag>Business</Tag> 
            </Phone> 
            <Email> 
                <Address>troy+steve@testing.com</Address> 
                <Default>true</Default> 
                <Tag>Business</Tag> 
            </Email> 
            <DBAName /> 
        </Object>
    </Add>

    <RestResponse xmlns="http://www.intuit.com/sb/cdm/v2">
        <Success RequestId="95bd8691b4b6d8a8e20d4a1eea28349c">
            <PartyRoleRef>
                <Id idDomain="NG">929334</Id>
                <SyncToken>1</SyncToken>
                <LastUpdatedTime>2013-08-26T04:14:30Z</LastUpdatedTime>
                <PartyReferenceId idDomain="NG">1008617</PartyReferenceId>
            </PartyRoleRef>
            <RequestName>CustomerAdd</RequestName>
            <ProcessedTime>2013-08-26T04:14:30Z</ProcessedTime>
        </Success>
    </RestResponse>
```

I have no idea how to communicate this in a short validation error :)
