### PR TITLE
Travis build failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,17 @@ rvm:
   - 1.9.3
   - 1.9.2
   - ree
+
+gemfile:
+  - gemfiles/3.2.Gemfile
+  - gemfiles/4.0.Gemfile
+
+matrix:
+  exclude:
+    - rvm: 1.9.2
+      gemfile: gemfiles/4.0.Gemfile
+    - rvm: ree
+      gemfile: gemfiles/4.0.Gemfile
+
 notifications:
   email: false

--- a/gemfiles/3.2.Gemfile
+++ b/gemfiles/3.2.Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "activemodel", "~> 3.2.14"
+
+gemspec :path=>"../"

--- a/gemfiles/4.0.Gemfile
+++ b/gemfiles/4.0.Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "activemodel", "~> 4.0.0"
+
+gemspec :path=>"../"


### PR DESCRIPTION
The [Travis build](https://travis-ci.org/ruckus/quickeebooks) is failing due to the activesupport 4.0.0 dependency requiring a ruby version >= 1.9.3. So either we need to remove support for ruby 1.9.2 and ree or pin activemodel to version 3.2.14 for those ruby versions. 

Let me know which you would prefer and I'll make a PR for it.
