### PR TITLE
Fix failing test on Ruby 2.0.0

### DIFF
--- a/spec/lib/quickeebooks/shared/service/filter_spec.rb
+++ b/spec/lib/quickeebooks/shared/service/filter_spec.rb
@@ -102,7 +102,7 @@ describe "Quickeebooks::Shared::Service::Filter" do
       it 'CGI escapes values' do
         filter.new(:text,
           :field => 'Foo',
-          :value => "<3 Bar's ><things").to_xml.should == '<Foo>&lt;3 Bar\'s &gt;&lt;things</Foo>'
+          :value => "<3 Bar ><things").to_xml.should == '<Foo>&lt;3 Bar &gt;&lt;things</Foo>'
       end
 
       it 'CGI escapes integers' do


### PR DESCRIPTION
I am getting a test failure under Ruby 2.0.0 when I am not getting one on 1.9.3. It seems that the behavior of CGI.escapeHTML was changed in Ruby 2, to where it now escapes apostrophes.
