### PR TITLE
Remove RR as a dependency

### DIFF
--- a/quickeebooks.gemspec
+++ b/quickeebooks.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'simplecov'
-  gem.add_development_dependency 'rr',     '~> 1.0.2'
   gem.add_development_dependency 'rspec',  '2.13.0'
   gem.add_development_dependency 'fakeweb'
   gem.add_development_dependency 'guard', '1.8.0'


### PR DESCRIPTION
We should not have dependencies in the gemspec that are not being used anywhere even if they are development dependencies.
