### PR TITLE
Modify ruby version support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 rvm:
   - 1.9.3
+  - 2.0.0
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,5 @@
 rvm:
   - 1.9.3
-  - 1.9.2
-  - ree
-
-gemfile:
-  - gemfiles/3.2.Gemfile
-  - gemfiles/4.0.Gemfile
-
-matrix:
-  exclude:
-    - rvm: 1.9.2
-      gemfile: gemfiles/4.0.Gemfile
-    - rvm: ree
-      gemfile: gemfiles/4.0.Gemfile
 
 notifications:
   email: false

--- a/gemfiles/3.2.Gemfile
+++ b/gemfiles/3.2.Gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "activemodel", "~> 3.2.14"
-
-gemspec :path=>"../"

--- a/gemfiles/4.0.Gemfile
+++ b/gemfiles/4.0.Gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "activemodel", "~> 4.0.0"
-
-gemspec :path=>"../"

--- a/quickeebooks.gemspec
+++ b/quickeebooks.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |gem|
 
   gem.files = Dir['lib/**/*']
 
+  gem.required_ruby_version = '>= 1.9.3'
+
   gem.add_dependency 'roxml'
   gem.add_dependency 'oauth'
   gem.add_dependency 'nokogiri', '~> 1.5.9'


### PR DESCRIPTION
This is a bit of a controversial PR I realize, so I'd like to open a discussion around this.

I basically explain the rationale behind this PR in the commit comments below but here they are again:

```
The gemspec requires activemodel, but does not specify a version
dependency. However, Rails 4 now requires >= 1.9.3. This means that it
is impossible to run `bundle` on 1.9.2 and REE, which means it's
impossible to develop on those versions. This is also causing tests to
not run on Travis.

Unfortunately, there isn't a good way to fix this in the gemspec, since
it's a bad idea to have conditional dependencies. While I'm sure some
people are still on 1.9.2, it is obsolete and unsupported. So the best
way to solve this is just to drop support.

This means we also no longer need to use custom Gemfiles on Travis.
These Gemfiles ensured that anything before 1.9.3 set the ActiveModel
dependency to 3.x and anything after was using 4.x. This is false
because this is inconsistent with what the gemspec is saying, which is
that quickeebooks depends on *any* version of ActiveModel (meaning that
people who install this gem on <= 1.9.3 will actually always get
ActiveModel 4, not 3).
```
