### PR TITLE
Fix gem deps so tests run under Ruby 1.9.2 and REE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,11 @@
 source 'http://rubygems.org'
 
+if Gem::Requirement.new('>= 1.9.3').satisfied_by? Gem::Version.new(RUBY_VERSION.dup)
+  gem 'activemodel', '~> 4.0'
+  gem 'listen'
+else
+  gem 'activemodel', '~> 3.0'
+  gem 'listen', '~> 1.0'
+end
+
 gemspec

--- a/gemfiles/3.2.Gemfile
+++ b/gemfiles/3.2.Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "activemodel", "~> 3.2.14"
+gem 'listen', '~> 1.0'
 
 gemspec :path=>"../"


### PR DESCRIPTION
- ActiveModel 4 requires Ruby >= 1.9.3, so ActiveModel 3 must be installed instead.
- Guard depends on the listen gem. Listen 2 also requires >= 1.9.3, so listen 1 must be installed instead.
