### PR TITLE
Remove adding lib to the load path as in RSpec 2.x, the lib directory is...

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,6 @@ require "rspec"
 require "fakeweb"
 require "oauth"
 
-$:.unshift "lib"
 require 'quickeebooks'
 
 Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |f| require f }


### PR DESCRIPTION
... automatically added to the load path. Only causing issues with Ruby 1.8.7
