### PR TITLE
Add "as Model::Id" to Windows#Account and Windows#Job

### DIFF
--- a/lib/quickeebooks/windows/model/account.rb
+++ b/lib/quickeebooks/windows/model/account.rb
@@ -15,7 +15,7 @@ module Quickeebooks
         REST_RESOURCE = "account"
 
         xml_convention :camelcase
-        xml_accessor :id, :from => 'Id'
+        xml_accessor :id, :from => 'Id', :as => Quickeebooks::Windows::Model::Id
         xml_accessor :sync_token, :from => 'SyncToken', :as => Integer
         xml_accessor :meta_data, :from => 'MetaData', :as => Quickeebooks::Windows::Model::MetaData
         xml_accessor :external_key, :from => 'ExternalKey'

--- a/lib/quickeebooks/windows/model/account_reference.rb
+++ b/lib/quickeebooks/windows/model/account_reference.rb
@@ -4,7 +4,7 @@ module Quickeebooks
   module Windows
     module Model
       class AccountReference < Quickeebooks::Windows::Model::IntuitType
-        xml_accessor :account_id, :from => 'AccountId'
+        xml_accessor :account_id, :from => 'AccountId', :as => Quickeebooks::Windows::Model::Id
         xml_accessor :account_name, :from => 'AccountName'
         xml_accessor :account_type, :from => 'AccountType'
 

--- a/lib/quickeebooks/windows/model/job.rb
+++ b/lib/quickeebooks/windows/model/job.rb
@@ -23,7 +23,7 @@ module Quickeebooks
         REST_RESOURCE = "job"
 
         xml_convention :camelcase
-        xml_accessor :id, :from => 'Id'
+        xml_accessor :id, :from => 'Id', :as => Quickeebooks::Windows::Model::Id
         xml_accessor :sync_token, :from => 'SyncToken', :as => Integer
         xml_accessor :meta_data, :from => 'MetaData', :as => Quickeebooks::Windows::Model::MetaData
         xml_accessor :external_key, :from => 'ExternalKey'


### PR DESCRIPTION
Account and Job were missing the `:as => Quickeebooks::Windows::Model::Id` part on their ID accessors.
