### PR TITLE
Add the ability to query sync responses using the NgIdSet method. See

### DIFF
--- a/lib/quickeebooks/windows/model/sync_status_request.rb
+++ b/lib/quickeebooks/windows/model/sync_status_request.rb
@@ -15,16 +15,21 @@ module Quickeebooks
         xml_convention :camelcase
         xml_accessor :offering_id
         xml_accessor :sync_status_param, :from => 'SyncStatusParam', :as => Quickeebooks::Windows::Model::SyncStatusParam
+        xml_accessor :ng_id_set, :from => 'NgIdSet', :as => Quickeebooks::Windows::Model::NgIdSet
 
-        def initialize(id = nil, type = nil)
+        def initialize(id = nil, type = nil, options = { :sync_status => true })
           self.offering_id = DEFAULT_OFFERING_ID
 
           if id && type
-            self.sync_status_param = Quickeebooks::Windows::Model::SyncStatusParam.new(id)
-            self.sync_status_param.object_type = type
+            if options[:sync_status]
+              self.sync_status_param = Quickeebooks::Windows::Model::SyncStatusParam.new(id)
+              self.sync_status_param.object_type = type
+            else
+              self.ng_id_set = Quickeebooks::Windows::Model::NgIdSet.new(id)
+              self.ng_id_set.ng_object_type = type
+            end
           end
         end
-
       end
     end
   end

--- a/spec/lib/quickeebooks/windows/service/sync_status_spec.rb
+++ b/spec/lib/quickeebooks/windows/service/sync_status_spec.rb
@@ -17,4 +17,34 @@ describe "Quickeebooks::Windows::Service::SyncStatus" do
     single_response.state_desc.should == "Next Gen record created"
   end
 
+  it "can fetch a single response using sync_status_param query method" do
+    xml = windowsFixture("single_sync_status_response.xml")
+    model = Quickeebooks::Windows::Model::SyncStatusRequest
+    FakeWeb.register_uri(:post, @service.url_for_resource(model::REST_RESOURCE), :status => ["200", "OK"], :body => xml)
+    id = 984434
+    request = Quickeebooks::Windows::Model::SyncStatusRequest.new(id, 'Payment')
+    expect(request.sync_status_param.to_i).to eq id
+    expect(request.sync_status_param.object_type).to eq 'Payment'
+    sync_status_responses = @service.retrieve(request)
+
+    expect(sync_status_responses.entries.count).to eq 1
+    single_response = sync_status_responses.entries.first
+    expect(single_response.ng_id_set.to_i).to eq id
+  end
+
+  it "can fetch a single response using sync statuses using ng_id_set method" do
+    xml = windowsFixture("single_sync_status_response.xml")
+    model = Quickeebooks::Windows::Model::SyncStatusRequest
+    FakeWeb.register_uri(:post, @service.url_for_resource(model::REST_RESOURCE), :status => ["200", "OK"], :body => xml)
+    id = 984434
+    request = Quickeebooks::Windows::Model::SyncStatusRequest.new(id, 'Payment', :sync_status => false)
+    expect(request.ng_id_set.to_i).to eq id
+    expect(request.ng_id_set.ng_object_type).to eq 'Payment'
+    sync_status_responses = @service.retrieve(request)
+
+    expect(sync_status_responses.entries.count).to eq 1
+    single_response = sync_status_responses.entries.first
+    expect(single_response.ng_id_set.to_i).to eq id
+  end
+
 end

--- a/spec/xml/windows/single_sync_status_response.xml
+++ b/spec/xml/windows/single_sync_status_response.xml
@@ -1,0 +1,16 @@
+<RestResponse xmlns="http://www.intuit.com/sb/cdm/v2" xmlns:xdb="http://xmlns.oracle.com/xdb" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.intuit.com/sb/cdm/v2 ../common/RestDataFilter.xsd">
+	<SyncStatusResponses> 
+		<SyncStatusResponse> 
+			<NgIdSet> 
+				<NgId>984434</NgId> 
+				<NgObjectType>Payment</NgObjectType> 
+			</NgIdSet> 
+			<RequestId>DE5403C9E3CADDD8E040900A0F1B294D</RequestId> 
+			<StateCode>8</StateCode> 
+			<StateDesc>Record netted with QB</StateDesc> 
+			<MessageCode>70</MessageCode> 
+			<MessageDesc>MBL Netter success using QB SDK ext_ack_id</MessageDesc> 
+			<ResponseLogTMS>2013-06-04T16:48:52.0Z</ResponseLogTMS> 
+		</SyncStatusResponse> 
+	</SyncStatusResponses>
+</RestResponse>


### PR DESCRIPTION
more at
https://developer.intuit.com/docs/95_deprecated/qbd_v2/qbd_v2_reference/0600_object_reference/syncstatus

Note: I am submitting this because I can't get the SyncStatusParam
method to work, which Intuit themselves acknowledge this to be the case
for QBD v2. The NgIdSet method does work based on my live testing
results.
