### PR TITLE
Add the post/get request XML to the exception. Being able to see the

### DIFF
--- a/lib/quickeebooks/online/service/service_base.rb
+++ b/lib/quickeebooks/online/service/service_base.rb
@@ -4,7 +4,7 @@ require 'cgi'
 require 'quickeebooks/common/logging'
 
 class IntuitRequestException < Exception
-  attr_accessor :code, :cause
+  attr_accessor :code, :cause, :request
   def initialize(msg)
     super(msg)
   end
@@ -148,7 +148,7 @@ module Quickeebooks
           log "HEADERS = #{headers.inspect}"
 
           response = @oauth.request(method, resource, body, headers)
-          check_response(response)
+          check_response(response, :request_xml => body)
         end
 
         def add_query_string_to_url(url, params)
@@ -159,7 +159,7 @@ module Quickeebooks
           end
         end
 
-        def check_response(response)
+        def check_response(response, options = {})
           log "RESPONSE CODE = #{response.code}"
           log "RESPONSE BODY = #{response.body}"
           status = response.code.to_i
@@ -175,6 +175,7 @@ module Quickeebooks
             ex = IntuitRequestException.new(err[:message])
             ex.code = err[:code]
             ex.cause = err[:cause]
+            ex.request = options[:request_xml]
             raise ex
           else
             raise "HTTP Error Code: #{status}, Msg: #{response.body}"

--- a/spec/lib/quickeebooks/online/service/service_base_spec.rb
+++ b/spec/lib/quickeebooks/online/service/service_base_spec.rb
@@ -51,6 +51,25 @@ describe "Quickeebooks::Online::Service::ServiceBase" do
 
     end
 
+    describe 'check_response' do
+      it "should throw request exception with no options" do
+        xml = onlineFixture('api_error.xml')
+        response = Struct.new(:code, :body).new(400, xml)
+        expect { @service.send(:check_response, response) }.to raise_error
+      end
+
+      it "should add post xml to request exception" do
+        xml = onlineFixture('api_error.xml')
+        xml2 = onlineFixture('customer.xml')
+        response = Struct.new(:code, :body).new(400, xml)
+        begin
+          @service.send(:check_response, response, :request_xml => xml2)
+        rescue IntuitRequestException => ex
+          ex.request.should == xml2
+        end
+      end
+    end
+
     context 'called from do_http_get' do
       it "without params" do
         url = "https://qbo.intuit.com/qbo1/rest/user/v2"

--- a/spec/lib/quickeebooks/windows/service/service_base_spec.rb
+++ b/spec/lib/quickeebooks/windows/service/service_base_spec.rb
@@ -3,6 +3,25 @@ describe "Quickeebooks::Windows::Service::ServiceBase" do
     construct_windows_service :service_base
   end
 
+  describe 'check_response' do
+    it "should throw request exception with no options" do
+      xml = onlineFixture('api_error.xml') # just use Online error fixture no difference
+      response = Struct.new(:code, :body).new(400, xml)
+      expect { @service.send(:check_response, response) }.to raise_error
+    end
+
+    it "should add post xml to request exception" do
+      xml = onlineFixture('api_error.xml')
+      xml2 = windowsFixture('customer.xml')
+      response = Struct.new(:code, :body).new(400, xml)
+      begin
+        @service.send(:check_response, response, :request_xml => xml2)
+      rescue IntuitRequestException => ex
+        ex.request.should == xml2
+      end
+    end
+  end
+
   describe "#fetch_collection" do
     let(:default_params){ "<StartPage>1</StartPage><ChunkSize>20</ChunkSize>" }
 


### PR DESCRIPTION
request XML can greatly speed up troubleshooting.
