### PR TITLE
Add the capability to add attributes to the main [Entity]Query xml tag.

### DIFF
--- a/lib/quickeebooks/windows/service/service_base.rb
+++ b/lib/quickeebooks/windows/service/service_base.rb
@@ -119,7 +119,11 @@ module Quickeebooks
           post_body_tags << custom_field_query
 
           xml_query_tag = "#{model::XML_NODE}Query"
-          body = %Q{<?xml version="1.0" encoding="utf-8"?>\n<#{xml_query_tag} xmlns="http://www.intuit.com/sb/cdm/v2">#{post_body_tags.join}</#{xml_query_tag}>}
+          close_tag = xml_query_tag
+          if options[:query_tag_attributes] && options[:query_tag_attributes].is_a?(Hash)
+            xml_query_tag += " " +  options[:query_tag_attributes].collect{ |a| %{#{a.first}="#{a.last}"} }.join(" ")
+          end
+          body = %Q{<?xml version="1.0" encoding="utf-8"?>\n<#{xml_query_tag} xmlns="http://www.intuit.com/sb/cdm/v2">#{post_body_tags.join}</#{close_tag}>}
 
           response = do_http_post(url_for_resource(model::REST_RESOURCE), body, {}, {'Content-Type' => 'text/xml'})
           parse_collection(response, model)

--- a/spec/lib/quickeebooks/windows/service/service_base_spec.rb
+++ b/spec/lib/quickeebooks/windows/service/service_base_spec.rb
@@ -93,5 +93,30 @@ describe "Quickeebooks::Windows::Service::ServiceBase" do
 
       @service.send(:fetch_collection, Object, nil, nil, 1, 20, sorter)
     end
+
+    context 'adding attributes to the main query tag' do
+      it "should add 1 attribute" do
+        @service.should_receive(:do_http_post).with(@url,
+          post_request_query('ErroredObjectsOnly="true"'),
+          {},
+          {"Content-Type"=>"text/xml"})
+        @service.send(:fetch_collection, Object, nil, nil, 1, 20, nil, :query_tag_attributes => { 'ErroredObjectsOnly' => 'true'})
+      end
+
+      it "should add 2 attributes" do
+        @service.should_receive(:do_http_post).with(@url,
+          post_request_query('ErroredObjectsOnly="true" ActiveOnly="true"'),
+          {},
+          {"Content-Type"=>"text/xml"})
+        @service.send(:fetch_collection, Object, nil, nil, 1, 20, nil, :query_tag_attributes => { 'ErroredObjectsOnly' => 'true', 'ActiveOnly' => 'true'})
+      end
+    end
+  end
+
+  def post_request_query(attrs)
+    xml = '<?xml version="1.0" encoding="utf-8"?>' + "\n"
+    xml += '<FooQuery %s xmlns="http://www.intuit.com/sb/cdm/v2">'
+    xml += '<StartPage>1</StartPage><ChunkSize>20</ChunkSize></FooQuery>'
+    xml % [attrs]
   end
 end


### PR DESCRIPTION
The main one I needed was ErroredObjectsOnly but there is ActiveOnly too.
I only implemented for QBD for now but if we see that there is a need
for this in QBO it can be done quickly.
